### PR TITLE
add namespace to build.gradle for gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace "com.example.ir_sensor_plugin"
+    }
     compileSdkVersion 31
 
     defaultConfig {


### PR DESCRIPTION
After upgrading a project to a new Gradle version, I got this error thrown at me:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':ir_sensor_plugin'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
```

https://developer.android.com/build/configure-app-module#set-namespace

Adding the namespace to the Gradle file fixed it.
